### PR TITLE
use provided instead of compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Gradle dependency for your Android app:
 
 Gradle dependency for your Java generator project:
 ```
-    compile 'org.greenrobot:greendao-generator:2.2.0'
+    provided 'org.greenrobot:greendao-generator:2.2.0'
 ```
 *Note:* to use encrypted databases using SQLCipher, you need to reference different artifacts (postfix '-encryption'). For all details, please refer to the documentation on [database encryption](http://greenrobot.org/greendao/documentation/database-encryption/).
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ Gradle dependency for your Android app:
 
 Gradle dependency for your Java generator project:
 ```
+    compile 'org.greenrobot:greendao-generator:2.2.0'
+```
+
+*Hint:* Use 'provided' if you are using the generator dependency in your Android project (in Android Studio for example), so it won't be included to your APK:
+```
     provided 'org.greenrobot:greendao-generator:2.2.0'
 ```
+
 *Note:* to use encrypted databases using SQLCipher, you need to reference different artifacts (postfix '-encryption'). For all details, please refer to the documentation on [database encryption](http://greenrobot.org/greendao/documentation/database-encryption/).
 
 Homepage, Documentation, Links

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Gradle dependency for your Java generator project:
     compile 'org.greenrobot:greendao-generator:2.2.0'
 ```
 
-*Hint:* Use 'provided' if you are using the generator dependency in your Android project (in Android Studio for example), so it won't be included to your APK:
+*Hint:* Use 'provided' if you are using the generator dependency in your Android project (in Android Studio for example), so it won't be included in your APK:
 ```
     provided 'org.greenrobot:greendao-generator:2.2.0'
 ```


### PR DESCRIPTION
Use provided instead of compile for the generator to exclude generator from the final apk. This helped to fix errors caused by the freemarker library when building the APK.
